### PR TITLE
Fixed method signature of respond_to? to recent one, to be compatible…

### DIFF
--- a/lib/simple/immutable.rb
+++ b/lib/simple/immutable.rb
@@ -67,7 +67,7 @@ class Simple::Immutable
       super
   end
 
-  def respond_to?(sym)
+  def respond_to?(sym, include_all = false)
     super || @hsh.key?(sym.to_s) || @hsh.key?(sym.to_sym)
   end
 


### PR DESCRIPTION
… with other libs. As for example table_print (or Ruby) will output a bunch of warnings about the old signature.

Docs https://ruby-doc.org/core-2.6.3/Object.html#method-i-respond_to-3F